### PR TITLE
Feat [Main App] [Module] typing banner

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
+	"github.com/H0llyW00dzZ/ChatGPT-Next-Web-Session-Exporter/bannercli"
 	"github.com/H0llyW00dzZ/go-urlshortner/datastore"
 	"github.com/H0llyW00dzZ/go-urlshortner/handlers"
 	"github.com/gin-gonic/gin"
@@ -16,13 +18,14 @@ func main() {
 	// Get the project ID from the "DATASTORE_PROJECT_ID" environment variable
 	projectID := os.Getenv("DATASTORE_PROJECT_ID")
 	if projectID == "" {
-		fmt.Println("DATASTORE_PROJECT_ID environment variable is not set.")
+		bannercli.PrintTypingBanner("DATASTORE_PROJECT_ID environment variable is not set.", 100*time.Millisecond)
 		os.Exit(1)
 	}
 
 	datastoreClient, err := datastore.CreateDatastoreClient(ctx, projectID)
 	if err != nil {
-		fmt.Printf("Failed to create datastore client: %v\n", err)
+		errorMessage := fmt.Sprintf("Failed to create datastore client: %v\n", err)
+		bannercli.PrintTypingBanner(errorMessage, 100*time.Millisecond)
 		os.Exit(1)
 	}
 
@@ -48,7 +51,8 @@ func main() {
 
 	fmt.Printf("Listening on port %s\n", port)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		fmt.Printf("Server failed to start: %v\n", err)
+		errorMessage := fmt.Sprintf("Server failed to start: %v\n", err)
+		bannercli.PrintTypingBanner(errorMessage, 100*time.Millisecond)
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go v0.111.0 // indirect
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	github.com/H0llyW00dzZ/ChatGPT-Next-Web-Session-Exporter v1.3.1 // indirect
 	github.com/chenzhuoyu/iasm v0.9.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2Aawl
 cloud.google.com/go/datastore v1.15.0 h1:0P9WcsQeTWjuD1H14JIY7XQscIPQ4Laje8ti96IC5vg=
 cloud.google.com/go/datastore v1.15.0/go.mod h1:GAeStMBIt9bPS7jMJA85kgkpsMkvseWWXiaHya9Jes8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/H0llyW00dzZ/ChatGPT-Next-Web-Session-Exporter v1.3.1 h1:yCPU6PckKW7hMgqqtLSGP6msEO2YVOVawWKdm+gYs4o=
+github.com/H0llyW00dzZ/ChatGPT-Next-Web-Session-Exporter v1.3.1/go.mod h1:JdikwQAKlB8q6uNhe8cfZSFT3bIoN5VC1BzWlwTU/rg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=


### PR DESCRIPTION
- [+] feat(app.go): add typing banner for missing DATASTORE_PROJECT_ID environment variable
- [+] fix(app.go): print error message with typing banner for failed datastore client creation
- [+] fix(app.go): print error message with typing banner for server failure to start
- [+] chore(go.mod): update ChatGPT-Next-Web-Session-Exporter to v1.3.1