### PR TITLE
Pass the zap logger instance

### DIFF
--- a/datastore/nosql.go
+++ b/datastore/nosql.go
@@ -33,6 +33,11 @@ var Logger *zap.Logger
 // ErrNotFound is the error returned when a requested entity is not found in the datastore.
 var ErrNotFound = errors.New("datastore: no such entity")
 
+// SetLogger sets the logger instance for the package.
+func SetLogger(logger *zap.Logger) {
+	Logger = logger
+}
+
 func init() {
 	// Initialize the zap logger with a development configuration.
 	// This config is console-friendly and outputs logs in plaintext.

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -30,6 +30,11 @@ var basePath string
 // It is set once during package initialization.
 var internalSecretValue string
 
+// SetLogger sets the logger instance for the package.
+func SetLogger(logger *zap.Logger) {
+	Logger = logger
+}
+
 func init() {
 	config := zap.NewDevelopmentConfig()
 	var err error

--- a/logmonitor/middleware.go
+++ b/logmonitor/middleware.go
@@ -49,6 +49,11 @@ import (
 // Logger is a global variable to access the zap logger throughout the logmonitor package.
 var Logger *zap.Logger
 
+// SetLogger sets the logger instance for the package.
+func SetLogger(logger *zap.Logger) {
+	Logger = logger
+}
+
 func init() {
 	// Initialize the zap logger with a development configuration.
 	// This config is console-friendly and outputs logs in plaintext.
@@ -75,7 +80,7 @@ func init() {
 //   - Duration taken to process the request
 //
 // The logs are output in a structured format, making them easy to read and parse.
-func RequestLogger() gin.HandlerFunc {
+func RequestLogger(logger *zap.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Start timer to track the duration of the request processing.
 		start := time.Now()
@@ -87,7 +92,7 @@ func RequestLogger() gin.HandlerFunc {
 		duration := time.Since(start)
 
 		// Log details of the request with zap.
-		Logger.Info("request details",
+		logger.Info("request details",
 			zap.Int("status", c.Writer.Status()),
 			zap.String("method", c.Request.Method),
 			zap.String("path", c.Request.URL.Path),


### PR DESCRIPTION
- [+] feat(app.go): initialize zap logger with development configuration
- [+] fix(app.go): change flushLogs function to defer logger.Sync() for flushing log entries
- [+] feat(app.go): pass logger instance to other packages
- [+] fix(app.go): change checkEnvironment function signature to accept logger parameter
- [+] fix(app.go): change handleStartupFailure function signature to accept logger parameter
- [+] fix(app.go): change initializeDatastoreClient function signature to accept logger parameter
- [+] fix(app.go): change setupRouter function signature to accept logger parameter
- [+] fix(app.go): change startServer function signature to accept logger parameter
- [+] feat(nosql.go): add SetLogger function to set logger instance for the package
- [+] feat(handlers.go): add SetLogger function to set logger instance for the package
- [+] feat(middleware.go): add SetLogger function to set logger instance for the package
- [+] feat(middleware.go): change RequestLogger function signature to accept logger parameter
- [+] feat(main.go): initialize zap logger with development configuration
- [+] fix(main.go): change flushLogs function to defer logger.Sync() for flushing log entries
- [+] feat(main.go): pass logger instance to other packages
- [+] fix(main.go): change checkEnvironment function signature to accept logger parameter
- [+] fix(main.go): change handleStartupFailure function signature to accept logger parameter
- [+] fix(main.go): change initializeDatastoreClient function signature to accept logger parameter
- [+] fix(main.go): change setupRouter function signature to accept logger parameter
- [+] fix(main.go): change startServer function signature to accept logger parameter