### PR TITLE
Feat [Package] [datastore] Custom Error & Update Docs

### DIFF
--- a/datastore/constant.go
+++ b/datastore/constant.go
@@ -15,6 +15,7 @@ const (
 	DataStoreFailedtoUpdateURL    = "Failed to update URL"
 	DataStoreFailedtoDeleteURL    = "Failed to delete URL"
 	DataStoreFailedToCloseClient  = "Failed to close client"
+	DataStoreAuthInvalidToken     = "reauthentication required due to invalid token."
 
 	// DataStoreNameKey is the name of the Kind in Datastore for URL entities.
 	// Defining it here enables changing the Kind name in one place if needed.
@@ -24,4 +25,10 @@ const (
 	InfoAttemptingToUpdateURLInDatastore = "Attempting to update URL in Datastore"
 	InfoFailedToUpdateURLInDatastore     = "Failed to update URL in Datastore"
 	InfoUpdateSuccessful                 = "URL updated successfully in the datastore"
+)
+
+// Define error constants.
+const (
+	noerrortoparse        = "no error to parse"
+	unexpectederrorformat = "unexpected error format"
 )

--- a/datastore/docs.go
+++ b/datastore/docs.go
@@ -3,68 +3,56 @@
 // updating, and deleting URL entities. It is designed to work with the URL shortener
 // service to manage shortened URLs and their corresponding original URLs.
 //
-// # Types:
+// # Types
 //
-// The Client type is a wrapper around the Google Cloud Datastore client that
-// provides additional methods for URL entity management. It abstracts away the
-// underlying datastore implementation details.
+//   - Client: Wraps the Google Cloud Datastore client and provides methods for URL entity management.
+//   - URL: Represents a URL entity within the datastore with fields for the original URL and a unique identifier.
+//   - DatastoreError: Represents structured errors from the Datastore client, including an error code, description, and optional details or URL.
 //
-//	type Client struct {
-//	    *cloudDatastore.Client
-//	}
+// # Variables
 //
-// The URL type represents a URL entity within the datastore, with fields for the
-// original URL and a unique identifier.
+//   - ErrNotFound: An error representing the absence of a URL entity in the datastore.
+//   - Logger: A package-level variable for consistent logging. It should be set using SetLogger before using logging functions.
 //
-//	type URL struct {
-//	    Original string `datastore:"original"` // The original URL.
-//	    ID       string `datastore:"id"`       // The unique identifier for the shortened URL.
-//	}
+// # Handler Functions
 //
-// # Variables:
+// The package offers functions for datastore operations:
+//   - CreateDatastoreClient: Initializes and returns a new datastore client.
+//   - SaveURL: Saves a URL entity to the datastore.
+//   - GetURL: Retrieves a URL entity from the datastore by ID.
+//   - UpdateURL: Updates an existing URL entity in the datastore.
+//   - DeleteURL: Deletes a URL entity from the datastore by ID.
+//   - CloseClient: Closes the datastore client and releases resources.
+//   - ParseDatastoreClientError: Parses errors from the Datastore client into a structured format.
 //
-// The package exposes an ErrNotFound variable, which is an error that represents
-// the absence of a URL entity in the datastore.
+// # Example Usage
 //
-//	var ErrNotFound = errors.New("no such entity")
-//
-// The package also includes a package-level Logger variable, which is intended to
-// be used across the datastore package for consistent logging.
-//
-//	var Logger *zap.Logger
-//
-// # Handlers Functions:
-//
-// The package provides functions to handle datastore operations. These functions
-// include creating a new client, saving, retrieving, updating, and deleting URL
-// entities.
-//
-//	func CreateDatastoreClient(ctx context.Context, config *Config) (*Client, error)
-//	func SaveURL(ctx context.Context, client *Client, url *URL) error
-//	func GetURL(ctx context.Context, client *Client, id string) (*URL, error)
-//	func UpdateURL(ctx context.Context, client *Client, id string, newURL string) error
-//	func DeleteURL(ctx context.Context, client *Client, id string) error
-//	func CloseClient(client *Client) error
-//
-// # Example of package usage:
+// The following example demonstrates how to initialize a datastore client, save a URL entity,
+// and retrieve it using the package's functions:
 //
 //	func main() {
 //	    logger, _ := zap.NewDevelopment()
+//	    defer logger.Sync()
+//
 //	    ctx := datastore.CreateContext()
 //	    config := datastore.NewConfig(logger, "my-project-id")
 //	    client, err := datastore.CreateDatastoreClient(ctx, config)
 //	    if err != nil {
 //	        logger.Fatal("Failed to create datastore client", zap.Error(err))
 //	    }
-//	    defer datastore.CloseClient(client)
+//	    defer func() {
+//	        if err := datastore.CloseClient(client); err != nil {
+//	            logger.Error("Failed to close datastore client", zap.Error(err))
+//	        }
+//	    }()
 //
-//	    // Use the client to interact with the datastore
+//	    // Use the client to save a new URL entity
 //	    url := &datastore.URL{Original: "https://example.com", ID: "abc123"}
 //	    if err := datastore.SaveURL(ctx, client, url); err != nil {
 //	        logger.Fatal("Failed to save URL", zap.Error(err))
 //	    }
 //
-//	    // Retrieve, update, or delete URLs as needed
+//	    // Retrieve the URL entity by ID
 //	    retrievedURL, err := datastore.GetURL(ctx, client, "abc123")
 //	    if err != nil {
 //	        logger.Error("Failed to retrieve URL", zap.Error(err))
@@ -73,16 +61,18 @@
 //	    }
 //	}
 //
-// The package functions are designed to be used in a concurrent environment and are
-// safe for use by multiple goroutines.
+// # Concurrency
 //
-// The CreateContext function is provided to create a new context for datastore
-// operations, which can be used to control the lifetime of requests and to pass
-// cancellation signals and other request-scoped values across API boundaries.
+// The package functions are designed for concurrent use and are safe for use by multiple goroutines.
 //
-// It is important to close the datastore client when it is no longer needed by
-// calling the CloseClient function to release any resources associated with the
-// client.
+// # Contexts
+//
+// The CreateContext function is provided for creating new contexts for datastore operations,
+// allowing for request lifetime control and value passing across API boundaries.
+//
+// # Cleanup
+//
+// It is important to close the datastore client with CloseClient to release resources.
 //
 // Copyright (c) 2023 by H0llyW00dzZ
 package datastore

--- a/datastore/nosql.go
+++ b/datastore/nosql.go
@@ -2,7 +2,10 @@ package datastore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 
 	cloudDatastore "cloud.google.com/go/datastore"
 	"github.com/H0llyW00dzZ/go-urlshortner/logmonitor"
@@ -11,35 +14,70 @@ import (
 )
 
 // Client wraps the cloudDatastore.Client to abstract away the underlying implementation.
+// This allows for easier mocking and testing, as well as decoupling the code from the specific datastore client used.
 type Client struct {
 	*cloudDatastore.Client
 }
 
 // URL represents a shortened URL with its original URL and a unique identifier.
+// The struct tags specify how each field is stored in the datastore.
 type URL struct {
 	Original string `datastore:"original"` // The original URL.
 	ID       string `datastore:"id"`       // The unique identifier for the shortened URL.
 }
 
 // Config holds the configuration settings for the datastore client.
+// This includes the logger for logging operations and the project ID for Google Cloud Datastore.
 type Config struct {
-	Logger    *zap.Logger
-	ProjectID string
+	Logger    *zap.Logger // The logger for logging operations within the datastore package.
+	ProjectID string      // The Google Cloud project ID where the datastore is located.
+}
+
+// DatastoreError represents a structured error for the Datastore client.
+// It includes details about the error code, description, and any additional details or URLs related to the error.
+type DatastoreError struct {
+	Code        string `json:"code"`                  // The error code.
+	Description string `json:"description"`           // The human-readable error description.
+	Details     string `json:"Details,omitempty"`     // Additional details about the error.
+	DetailsURL  string `json:"details_url,omitempty"` // A URL with more information about the error, if available.
+}
+
+// Error implements the error interface for DatastoreError.
+// This method formats the DatastoreError into a string, including the details URL if present.
+func (e *DatastoreError) Error() string {
+	if e.DetailsURL != "" {
+		return fmt.Sprintf("Code: %s, Description: %s, Details: %s", e.Code, e.Description, e.DetailsURL)
+	}
+	return fmt.Sprintf("Code: %s, Description: %s", e.Code, e.Description)
+}
+
+// MarshalJSON ensures that the DatastoreError is marshaled correctly.
+// It overrides the default JSON marshaling to include only the relevant fields.
+func (e *DatastoreError) MarshalJSON() ([]byte, error) {
+	type Alias DatastoreError
+	return json.Marshal(&struct {
+		*Alias
+	}{
+		Alias: (*Alias)(e),
+	})
 }
 
 // Logger is a package-level variable to access the zap logger throughout the datastore package.
-// It is intended to be used by other functions within the package for logging purposes.
+// It can be set using the SetLogger function and is used by various functions for consistent logging.
 var Logger *zap.Logger
 
 // ErrNotFound is the error returned when a requested entity is not found in the datastore.
+// This error is used to signal that a URL entity with the provided ID does not exist.
 var ErrNotFound = errors.New(DataStoreNosuchentity)
 
 // SetLogger sets the logger instance for the package.
+// This function configures the package-level Logger variable for use throughout the datastore package.
 func SetLogger(logger *zap.Logger) {
 	Logger = logger
 }
 
 // NewConfig creates a new instance of Config with the given logger and project ID.
+// This function is used to configure the datastore client with necessary settings.
 func NewConfig(logger *zap.Logger, projectID string) *Config {
 	return &Config{
 		Logger:    logger,
@@ -48,14 +86,15 @@ func NewConfig(logger *zap.Logger, projectID string) *Config {
 }
 
 // CreateContext creates a new context that can be used for Datastore operations.
-// It returns a non-nil, empty context.
+// It returns a non-nil, empty context that can be used to carry deadlines, cancellation signals,
+// and other request-scoped values across API boundaries and between processes.
 func CreateContext() context.Context {
 	return context.Background()
 }
 
 // CreateDatastoreClient creates a new client connected to Google Cloud Datastore.
-// It requires a context and a Config struct to initialize the connection.
-// It returns a new Datastore client wrapped in a custom Client type or an error if the connection could not be established.
+// It initializes the connection using the provided context and configuration settings.
+// The function returns a new Client instance or an error if the connection could not be established.
 func CreateDatastoreClient(ctx context.Context, config *Config) (*Client, error) {
 	cloudClient, err := cloudDatastore.NewClient(ctx, config.ProjectID)
 	if err != nil {
@@ -73,9 +112,8 @@ func CreateDatastoreClient(ctx context.Context, config *Config) (*Client, error)
 }
 
 // SaveURL saves a new URL entity to Datastore under the Kind 'urlz'.
-// It takes a context, a Datastore client, and a URL struct.
-// If the Kind 'urlz' does not exist, Datastore will create it automatically.
-// Returns an error if the URL entity could not be saved.
+// It uses the provided context and datastore client to save the URL struct to the datastore.
+// The function returns an error if the URL entity could not be saved.
 func SaveURL(ctx context.Context, client *Client, url *URL) error {
 	key := cloudDatastore.NameKey(DataStoreNameKey, url.ID, nil)
 	_, err := client.Put(ctx, key, url)
@@ -88,8 +126,8 @@ func SaveURL(ctx context.Context, client *Client, url *URL) error {
 }
 
 // GetURL retrieves a URL entity by its ID from Datastore.
-// It requires a context, a Datastore client, and the ID of the URL entity.
-// Returns the URL entity or an error if the entity could not be retrieved.
+// It uses the provided context and datastore client to look up the URL entity by its unique identifier.
+// The function returns the found URL entity or an error if the entity could not be retrieved.
 func GetURL(ctx context.Context, dsClient *Client, id string) (*URL, error) {
 	key := cloudDatastore.NameKey(DataStoreNameKey, id, nil)
 	url := new(URL)
@@ -105,8 +143,8 @@ func GetURL(ctx context.Context, dsClient *Client, id string) (*URL, error) {
 }
 
 // UpdateURL updates an existing URL entity in Datastore with a new URL.
-// It requires a context, a Datastore client, the ID of the URL entity, and the new URL to update.
-// Returns an error if the URL entity could not be updated.
+// It performs the update within a transaction to ensure the operation is atomic.
+// The function returns an error if the URL entity could not be updated.
 func UpdateURL(ctx context.Context, client *Client, id string, newURL string) error {
 	key := cloudDatastore.NameKey(DataStoreNameKey, id, nil)
 	// Transactionally retrieve the existing URL and update it.
@@ -134,8 +172,8 @@ func UpdateURL(ctx context.Context, client *Client, id string, newURL string) er
 }
 
 // DeleteURL deletes a URL entity by its ID from Datastore.
-// It requires a context, a Datastore client, and the ID of the URL entity.
-// Returns an error if the entity could not be deleted.
+// It uses the provided context and datastore client to delete the URL entity by its unique identifier.
+// The function returns an error if the entity could not be deleted.
 func DeleteURL(ctx context.Context, client *Client, id string) error {
 	key := cloudDatastore.NameKey(DataStoreNameKey, id, nil)
 	err := client.Delete(ctx, key)
@@ -152,7 +190,7 @@ func DeleteURL(ctx context.Context, client *Client, id string) error {
 
 // CloseClient closes the Datastore client.
 // It should be called to clean up resources and connections when the client is no longer needed.
-// Returns an error if the client could not be closed.
+// The function returns an error if the client could not be closed.
 func CloseClient(client *Client) error {
 	if client == nil {
 		return nil // or return an error if you expect the client to never be nil
@@ -163,4 +201,51 @@ func CloseClient(client *Client) error {
 		return err
 	}
 	return nil
+}
+
+// ParseDatastoreClientError parses the error from the Datastore client and returns a structured error.
+// It attempts to extract meaningful information from the error returned by the datastore client
+// and formats it into a DatastoreError. It returns the structured error and a parsing error, if any.
+func ParseDatastoreClientError(err error) (*DatastoreError, error) {
+	if err == nil {
+		return nil, fmt.Errorf(noerrortoparse)
+	}
+
+	errorMessage := err.Error()
+	parts := strings.Fields(errorMessage) // Use Fields to automatically handle splitting by whitespace.
+	if len(parts) < 2 {
+		return nil, fmt.Errorf(unexpectederrorformat)
+	}
+
+	datastoreErr := &DatastoreError{
+		Code:    parts[0],                     // Assuming the code is the first part of the error message.
+		Details: strings.Join(parts[1:], " "), // The rest is the details.
+	}
+
+	datastoreErr.DetailsURL = extractDetailsURL(errorMessage)
+	datastoreErr = checkForSpecificError(errorMessage, datastoreErr)
+
+	return datastoreErr, nil
+}
+
+// extractDetailsURL extracts the details URL from the error message if present.
+// It looks for an "http" substring and assumes that the URL is the last part of the error message.
+// The function returns the extracted URL or an empty string if no URL is found.
+func extractDetailsURL(errorMessage string) string {
+	if strings.Contains(errorMessage, "http") {
+		parts := strings.Fields(errorMessage)
+		return strings.Trim(parts[len(parts)-1], "\"") // Assuming the URL is the last part.
+	}
+	return ""
+}
+
+// checkForSpecificError checks for specific errors and updates the DatastoreError accordingly.
+// It looks for known error patterns in the error message and sets the appropriate description
+// and details in the DatastoreError. The function returns the updated DatastoreError.
+func checkForSpecificError(errorMessage string, datastoreErr *DatastoreError) *DatastoreError {
+	if strings.Contains(errorMessage, "invalid_grant") {
+		datastoreErr.Description = DataStoreAuthInvalidToken
+		datastoreErr.Details = errorMessage
+	}
+	return datastoreErr
 }


### PR DESCRIPTION
- [+] docs(datastore/docs.go): update types, variables, and handler functions documentation
- [+] feat(datastore/docs.go): add example usage section
- [+] docs(datastore/docs.go): update concurrency and contexts documentation
- [+] docs(datastore/docs.go): update cleanup documentation
- [+] feat(datastore/docs.go): add ParseDatastoreClientError function for parsing Datastore client errors
- [+] chore(constant.go): add constant for invalid token authentication error
- [+] chore(constant.go): add error constants for parsing and unexpected error format