### PR TITLE
Refactor [Package] [Handlers] Rate Limiter

### DIFF
--- a/handlers/url.go
+++ b/handlers/url.go
@@ -22,7 +22,6 @@ func getURLHandlerGin(dsClient *datastore.Client) gin.HandlerFunc {
 		}
 
 		id := c.Param(constant.HeaderID) // Use a string directly if it's not a constant that changes.
-		logAttemptToRetrieve(id)         // Pass Context Log
 
 		url, err := datastore.GetURL(c.Request.Context(), dsClient, id) // Use the request's context
 		if err != nil {
@@ -66,8 +65,11 @@ func handleGetURLError(c *gin.Context, id string, err error) {
 // for indicate that client/user are bad requesting, not the server.
 func applyRateLimit(c *gin.Context) bool {
 	key := c.ClientIP()
+	id := c.Param(constant.HeaderID) // Use a string directly if it's not a constant that changes.
 	limiter := NewRateLimiter(key, rate.Limit(1), 10)
 	if !limiter.Allow() {
+		// Log with an emoji to indicate rate limiting has occurred.
+		logAttemptToRetrieve(id) // Pass Context Log
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
 			constant.HeaderResponseError: constant.URLnotfoundContextLog,
 		})


### PR DESCRIPTION
- [+] refactor(url.go): remove unnecessary logAttemptToRetrieve function call
- [+] feat(url.go): add logging with emoji to indicate rate limiting has occurred

Better
```sh
2023-12-20T20:03:16.104+0700    INFO    handlers/logger.go:36   🚨  ⚠️  Attempting to retrieve the current URL  {"operation": "retrieve", "id": "0x1337"}
2023-12-20T20:03:16.105+0700    INFO    logmonitor/middleware.go:140    ☸️  ⚠️  Request Details {"hostmachine_start_time": "2023/12/20 - 20:03:16", "status": 404, "method": "GET T", "path": "/0x1337", "duration": "0ms"}
2023-12-20T20:03:16.227+0700    INFO    handlers/logger.go:36   🚨  ⚠️  Attempting to retrieve the current URL  {"operation": "retrieve", "id": "0x1337"}
2023-12-20T20:03:16.227+0700    INFO    logmonitor/middleware.go:140    ☸️  ⚠️  Request Details {"hostmachine_start_time": "2023/12/20 - 20:03:16", "status": 404, "method": "GET T", "path": "/0x1337", "duration": "0ms"}
2023-12-20T20:03:16.339+0700    INFO    handlers/logger.go:36   🚨  ⚠️  Attempting to retrieve the current URL  {"operation": "retrieve", "id": "0x1337"}
2023-12-20T20:03:16.339+0700    INFO    logmonitor/middleware.go:140    ☸️  ⚠️  Request Details {"hostmachine_start_time": "2023/12/20 - 20:03:16", "status": 404, "method": "GET T", "path": "/0x1337", "duration": "0ms"}
2023-12-20T20:03:16.436+0700    INFO    handlers/logger.go:36   🚨  ⚠️  Attempting to retrieve the current URL  {"operation": "retrieve", "id": "0x1337"}
2023-12-20T20:03:16.436+0700    INFO    logmonitor/middleware.go:140    ☸️  ⚠️  Request Details {"hostmachine_start_time": "2023/12/20 - 20:03:16", "status": 404, "method": "GET T", "path": "/0x1337", "duration": "0ms"}
```