### PR TITLE
[Package] [WorkerK8S] Reduce Gocyclo keep it under 5

### DIFF
--- a/workerk8s/internal.go
+++ b/workerk8s/internal.go
@@ -5,13 +5,16 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// NewKubernetesClient creates and returns a new Kubernetes client.
+// NewKubernetesClient creates a new Kubernetes client using the in-cluster configuration.
+// This is typically used when the application itself is running within a Kubernetes cluster.
 func NewKubernetesClient() (*kubernetes.Clientset, error) {
+	// Get the in-cluster config.
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
 	}
 
+	// Create a clientset based on the in-cluster config.
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/workerk8s/k8s.go
+++ b/workerk8s/k8s.go
@@ -4,20 +4,23 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// RunWorkers starts a number of worker goroutines and collects their results.
+// RunWorkers starts the specified number of worker goroutines to perform health checks on pods and collects their results.
 func RunWorkers(clientset *kubernetes.Clientset, numWorkers int, namespace string) []string {
 	results := make(chan string)
 	var collectedResults []string
 
+	// Start worker goroutines.
 	for i := 0; i < numWorkers; i++ {
 		go Worker(clientset, namespace, results)
 	}
 
+	// Collect results from the workers.
 	for i := 0; i < numWorkers; i++ {
 		collectedResults = append(collectedResults, <-results)
 	}
 
-	close(results) // Close the channel when all results have been collected
+	// It's important to close the channel to avoid a goroutine leak.
+	close(results)
 
 	return collectedResults
 }

--- a/workerk8s/label_pods.go
+++ b/workerk8s/label_pods.go
@@ -4,29 +4,46 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-// LabelPods sets a label on all pods in a given namespace.
+// LabelPods sets a specific label on all pods within the specified namespace that do not already have it.
 func LabelPods(clientset *kubernetes.Clientset, namespace, labelKey, labelValue string) error {
+	// Retrieve a list of all pods in the given namespace.
 	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), v1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf(ErrorListingPods, err)
 	}
 
+	// Iterate over the list of pods and update their labels if necessary.
 	for _, pod := range pods.Items {
-		if pod.Labels[labelKey] == labelValue {
-			continue
+		if err := labelSinglePod(clientset, &pod, namespace, labelKey, labelValue); err != nil {
+			return err
 		}
-		podCopy := pod.DeepCopy()
-		if podCopy.Labels == nil {
-			podCopy.Labels = map[string]string{}
-		}
-		podCopy.Labels[labelKey] = labelValue
-		if _, err := clientset.CoreV1().Pods(namespace).Update(context.Background(), podCopy, v1.UpdateOptions{}); err != nil {
-			return fmt.Errorf(ErrorUpdatingPodLabels, err)
-		}
+	}
+	return nil
+}
+
+// labelSinglePod applies the label to a single pod if it doesn't already have it.
+func labelSinglePod(clientset *kubernetes.Clientset, pod *corev1.Pod, namespace, labelKey, labelValue string) error {
+	// If the pod already has the label with the correct value, skip updating.
+	if pod.Labels[labelKey] == labelValue {
+		return nil
+	}
+
+	// Prepare the pod's labels for update or create a new label map if none exist.
+	podCopy := pod.DeepCopy()
+	if podCopy.Labels == nil {
+		podCopy.Labels = make(map[string]string)
+	}
+	podCopy.Labels[labelKey] = labelValue
+
+	// Update the pod with the new label.
+	_, err := clientset.CoreV1().Pods(namespace).Update(context.Background(), podCopy, v1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf(ErrorUpdatingPodLabels, err)
 	}
 	return nil
 }


### PR DESCRIPTION
- [+] feat(workerk8s/internal.go): add NewKubernetesClient function to create a new Kubernetes client using in-cluster configuration
- [+] feat(workerk8s/k8s.go): add RunWorkers function to start worker goroutines and collect their results
- [+] feat(workerk8s/label_pods.go): add LabelPods function to set a specific label on all pods within a namespace that do not already have it
- [+] feat(workerk8s/worker.go): add Worker function to perform health checks on pods and send results to a channel
- [+] refactor(workerk8s/label_pods.go): extract labelSinglePod function to apply label to a single pod if it doesn't already have it
- [+] refactor(workerk8s/worker.go): extract isPodHealthy function to determine if a pod is considered "healthy" based on its phase and container statuses